### PR TITLE
39 timeout config v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,14 @@ VisualRegressionTrackerConfig config = new VisualRegressionTrackerConfig(
     "develop",
     
     // enableSoftAssert - Log errors instead of exceptions
-    false
+    false,
+ 
+    // ciBuildId - id of the build in CI system
+    "CI_BUILD_ID",
+    
+    // httpTimeoutInSeconds - define http socket timeout in seconds (default 10s)
+    15
+
 );
 ```
 

--- a/src/main/java/io/visual_regression_tracker/sdk_java/VisualRegressionTracker.java
+++ b/src/main/java/io/visual_regression_tracker/sdk_java/VisualRegressionTracker.java
@@ -2,6 +2,7 @@ package io.visual_regression_tracker.sdk_java;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import com.google.gson.Gson;
 import io.visual_regression_tracker.sdk_java.request.BuildRequest;
@@ -31,7 +32,11 @@ public class VisualRegressionTracker {
     public VisualRegressionTracker(VisualRegressionTrackerConfig trackerConfig) {
         configuration = trackerConfig;
         paths = new PathProvider(trackerConfig.getApiUrl());
-        client = new OkHttpClient();
+        client = new OkHttpClient.Builder()
+                .connectTimeout(configuration.getHttpTimeoutInSeconds(), TimeUnit.SECONDS)
+                .readTimeout(configuration.getHttpTimeoutInSeconds(), TimeUnit.SECONDS)
+                .writeTimeout(configuration.getHttpTimeoutInSeconds(), TimeUnit.SECONDS)
+                .build();
         gson = new Gson();
     }
 

--- a/src/main/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerConfig.java
+++ b/src/main/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerConfig.java
@@ -24,4 +24,6 @@ public class VisualRegressionTrackerConfig {
     private Boolean enableSoftAssert = false;
     @Builder.Default
     private String ciBuildId = null;
+    @Builder.Default
+    private int httpTimeoutInSeconds = 10;
 }

--- a/src/test/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerTest.java
+++ b/src/test/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerTest.java
@@ -29,8 +29,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import javax.net.ServerSocketFactory;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerTest.java
+++ b/src/test/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerTest.java
@@ -1,8 +1,10 @@
 package io.visual_regression_tracker.sdk_java;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -27,6 +29,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.net.ServerSocketFactory;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,6 +50,7 @@ public class VisualRegressionTrackerTest {
     private final static String CI_BUILD_ID = "123456789";
     private final static String NAME = "Test name";
     private final static String IMAGE_BASE_64 = "image";
+    private final static int HTTP_TIMOUT = 1;
 
     private final Gson gson = new Gson();
 
@@ -67,7 +72,8 @@ public class VisualRegressionTrackerTest {
                 "XHGDZDFD3GMJDNM87JKEMP0JS1G5",
                 "develop",
                 false,
-                CI_BUILD_ID);
+                CI_BUILD_ID,
+                HTTP_TIMOUT);
         vrt = new VisualRegressionTracker(config);
         vrtMocked = mock(VisualRegressionTracker.class);
         vrtMocked.paths = new PathProvider("baseApiUrl");
@@ -338,5 +344,45 @@ public class VisualRegressionTrackerTest {
         }
 
         assertThat(exceptionMessage, is(error));
+    }
+
+    @Test
+    public void httpTimoutWorks() throws IOException, InterruptedException {
+        BuildResponse buildResponse = BuildResponse.builder()
+                .id(BUILD_ID)
+                .projectId(PROJECT_ID)
+                .ciBuildId(CI_BUILD_ID)
+                .build();
+        String json = gson.toJson(buildResponse);
+        //body size is 97 bytes, http timeout is 1s, set body read delay to 0.9s, wait that vrt get all values correctly
+        server.enqueue(new MockResponse().throttleBody(json.length(), HTTP_TIMOUT * 1000 - 100, TimeUnit.MILLISECONDS)
+                .setResponseCode(200)
+                .setBody(json));
+
+        vrt.start();
+
+        server.takeRequest();
+
+        assertThat(vrt.buildId, is(BUILD_ID));
+        assertThat(vrt.projectId, is(PROJECT_ID));
+    }
+
+    @Test(expectedExceptions = SocketTimeoutException.class,
+            expectedExceptionsMessageRegExp = "^(timeout|Read timed out)$")
+    public void httpTimoutElapsed() throws IOException, InterruptedException {
+        BuildResponse buildResponse = BuildResponse.builder()
+                .id(BUILD_ID)
+                .projectId(PROJECT_ID)
+                .ciBuildId(CI_BUILD_ID)
+                .build();
+        String json = gson.toJson(buildResponse);
+        //body size is 97 bytes, http timeout is 1s, set body read delay to 1s, wait for error
+        server.enqueue(new MockResponse().throttleBody(json.length(), HTTP_TIMOUT, TimeUnit.SECONDS)
+                .setResponseCode(200)
+                .setBody(json));
+
+        vrt.start();
+
+        server.takeRequest();
     }
 }


### PR DESCRIPTION
Add httpTimeoutInSeconds with default value 10 that helps to configure socket timeout

```        
config = VisualRegressionTrackerConfig.builder()
                .apiUrl("URL")
                .apiKey("6NK4QdfsdsMsdf7NfsdfdsFJ9KNPB3")
                .project("92343c-21344-4b348-b02a-37448189f178")
                .branchName("master")
                .httpTimeoutInSeconds(15)
                .build();
```
Add tests for this functionality