### PR TITLE
add autoApproved status;

### DIFF
--- a/src/main/java/io/visual_regression_tracker/sdk_java/TestRunStatus.java
+++ b/src/main/java/io/visual_regression_tracker/sdk_java/TestRunStatus.java
@@ -11,6 +11,8 @@ public enum TestRunStatus {
     OK,
     @SerializedName("approved")
     APPROVED,
+    @SerializedName("autoApproved")
+    AUTO_APPROVED,
     @SerializedName("failed")
     FAILED,
     @SerializedName("new")

--- a/src/test/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerTest.java
+++ b/src/test/java/io/visual_regression_tracker/sdk_java/VisualRegressionTrackerTest.java
@@ -286,6 +286,20 @@ public class VisualRegressionTrackerTest {
                                 .url("https://someurl.com/test/123123")
                                 .status(TestRunStatus.OK)
                                 .build(),
+                },
+                {
+                        TestRunResponse.builder()
+                                .id("someId")
+                                .imageName("imageName")
+                                .baselineName("baselineName")
+                                .diffName("diffName")
+                                .diffPercent(12.32f)
+                                .diffTollerancePercent(0.01f)
+                                .pixelMisMatchCount(1)
+                                .merge(false)
+                                .url("https://someurl.com/test/123123")
+                                .status(TestRunStatus.AUTO_APPROVED)
+                                .build(),
                 }
         };
     }


### PR DESCRIPTION
When the response had an autoApproved status, Gson could not correctly parse the status on this method:

```
protected <T> T handleResponse(HttpResponse<String> response, Class<T> classOfT) {
        String responseBody = response.body();
        if (!String.valueOf(response.statusCode()).startsWith("2")) {
            throw new TestRunException(responseBody);
        }
        return gson.fromJson(responseBody, classOfT);
    }
```

This resulted in a further NPE in the method `track`.