### PR TITLE
use full project name in produced artefact

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'sdk-java'
+rootProject.name = 'visual-regression-tracker-sdk-java'
 


### PR DESCRIPTION
avoids uninformative sdk-java.jar file name for java client library