### PR TITLE
make TestRunException available outiside of the package

### DIFF
--- a/src/main/java/io/visual_regression_tracker/sdk_java/TestRunException.java
+++ b/src/main/java/io/visual_regression_tracker/sdk_java/TestRunException.java
@@ -1,6 +1,6 @@
 package io.visual_regression_tracker.sdk_java;
 
-class TestRunException extends RuntimeException {
+public class TestRunException extends RuntimeException {
     public TestRunException(String errorMessage) {
         super(errorMessage);
     }


### PR DESCRIPTION
In some cases, it would be helpful if we can catch `TestRunException` exception thrown in `track()` method and process it based on the needs.  For example, we might need to capture a few screenshots per test scenario, send them to backend but do not fail if the first one has difference. 